### PR TITLE
Drop login control and session dependency

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,19 +1,11 @@
 from starlette.applications import Starlette
-from starlette.config import Config
-from starlette.routing import Route, Mount
+from starlette.routing import Mount
 from starlette.templating import Jinja2Templates
 from starlette.staticfiles import StaticFiles
-from starlette.middleware import Middleware
-from starlette.middleware.sessions import SessionMiddleware
 import databases
 import dashboard
 import orm
 import datetime
-
-
-config = Config()
-SECRET_KEY = config('SECRET_KEY', cast=str, default='123')
-HTTPS_ONLY = config('HTTPS_ONLY', cast=bool, default=False)
 
 
 database = databases.Database('sqlite:///test.db')
@@ -46,8 +38,4 @@ routes = [
     Mount("/statics", app=statics, name='static')
 ]
 
-middleware = [
-    Middleware(SessionMiddleware, secret_key=SECRET_KEY, https_only=HTTPS_ONLY)
-]
-
-app = Starlette(debug=True, routes=routes, middleware=middleware, on_startup=[database.connect], on_shutdown=[database.disconnect])
+app = Starlette(debug=True, routes=routes, on_startup=[database.connect], on_shutdown=[database.disconnect])

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,7 @@ uvicorn
 jinja2
 itsdangerous
 typesystem==0.3.0.dev0
+
+# Tests
 pytest
+requests

--- a/templates/dashboard/base.html
+++ b/templates/dashboard/base.html
@@ -25,24 +25,6 @@
       <div class="container">
         <a class="navbar-brand" href="{{ url_for('dashboard:index') }}">Starlette</a>
         <ul class="navbar-nav mr-auto"></ul>
-        {% if request.session.username %}
-        <div class="dropdown">
-          <a style="color: white" class="dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            <img src="{{ request.session.avatar_url }}" class="rounded float-left" alt="{{ request.session.username }}" width=20px height=20px/>
-          </a>
-
-          <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuLink">
-            <p class="dropdown-header">Logged in as <strong>{{ request.session.username }}</strong></p>
-            <div class="dropdown-divider"></div>
-            <div class="dropdown-divider"></div>
-            <form action="{{ url_for('auth:logout') }}" method="POST"><button class="dropdown-item btn-link" type="submit">Logout</button></form>
-          </div>
-        </div>
-        {% else %}
-        <form class="form-inline" action="{{ url_for('auth:login') }}", method="POST">
-          <button class="btn btn-outline-light" type="submit">Login</button>
-        </form>
-        {% endif %}
       </div>
     </nav>
     {% block content %}{% endblock %}

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -1,0 +1,17 @@
+import dashboard
+from starlette.applications import Starlette
+from starlette.routing import Mount
+from starlette.staticfiles import StaticFiles
+from starlette.testclient import TestClient
+
+
+def test_index():
+    app = Starlette(
+        routes=[
+            Mount('/admin', dashboard.Dashboard(tables=[]), name='dashboard'),
+            Mount('/statics', StaticFiles(), name='static'),
+        ]
+    )
+    client = TestClient(app=app)
+    response = client.get("/admin")
+    assert response.status_code == 200


### PR DESCRIPTION
Given that there's currently no auth endpoints and login/logout, this PR drops the "login" display, and the `SessionMiddleware` dependency.

This is an area that needs some more thinking about in order to get to a Starlette 1.0 release.