### PR TITLE
Update workflow

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -2,8 +2,6 @@
 name: Test Suite
 
 on:
-  push:
-    branches: ["master"]
   pull_request:
     branches: ["master"]
 


### PR DESCRIPTION
Right now we have CI running both on PRs, and on merge to master.

I'm interested to see if we could instead turn on this setting...

<img width="684" alt="Screenshot 2020-04-28 at 12 26 37" src="https://user-images.githubusercontent.com/647359/80482150-9c890780-894b-11ea-8f0d-a09258062ca6.png">

And then *only* run CI on pull requests.