### PR TITLE
Rename "Publish" workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,5 @@
 ---
-name: Publish to PyPI
+name: Publish
 
 on:
   push:


### PR DESCRIPTION
Rename workflow from "Publish to PyPI" to "Publish".

(Since we're *also* updating the docs on publish, the generic name is more appropriate)