### PR TITLE
Enforce can_create, can_edit, can_delete in API

### DIFF
--- a/dashboard/application.py
+++ b/dashboard/application.py
@@ -227,7 +227,9 @@ class DashboardTable:
 
     async def _get_item(self, request):
         ident = request.path_params["ident"]
-        item = await self.datasource.filter(self.LOOKUP_FIELD=ident).get()
+        lookup = {self.LOOKUP_FIELD: ident}
+
+        item = await self.datasource.filter(**lookup).get()
         if item is None:
             raise HTTPException(status_code=404)
 

--- a/dashboard/application.py
+++ b/dashboard/application.py
@@ -227,9 +227,7 @@ class DashboardTable:
 
     async def _get_item(self, request):
         ident = request.path_params["ident"]
-        lookup = {self.LOOKUP_FIELD: ident}
-
-        item = await self.datasource.filter(**lookup).get()
+        item = await self.datasource.filter(self.LOOKUP_FIELD=ident).get()
         if item is None:
             raise HTTPException(status_code=404)
 


### PR DESCRIPTION
Before this, `can_create`, `can_edit` and `can_delete` applied only to the template rendering.
This will enforce they are applied to API level too.

This was separated from previous commit as it needed some refactoring to make that work.

The most important change I think is here.
Before this, we'd only tested one datasource with dashboard, and when I added the second model in test, it still returned urls for the first datasource. So the second one was always ignored.
I'm dynamically creating name of endpoints and accessing them now. Not sure if it's the best approach, but works for now.